### PR TITLE
Generate `CakeworkClient` instead of `CakeworkApiClient`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -3,7 +3,9 @@ groups:
   external:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.0.262
+        version: 0.0.266
         output:
           location: local-file-system
           path: ../../sdk/typescript/src
+        config: 
+          namespaceExport: Cakework


### PR DESCRIPTION
This PR upgrades the typescript-sdk generator to `0.0.266`. @zachkirsch updated the TypeScript SDK generator to support naming the client (https://github.com/fern-api/fern-typescript/pull/278). 

This PR will autogenere `CakeworkClient` instead of `CakeworkApiClient`